### PR TITLE
修复并发场景下的高cpu&内存占用

### DIFF
--- a/ware-drool-rule/src/main/java/com/drool/engine/config/RuleEngineConfig.java
+++ b/ware-drool-rule/src/main/java/com/drool/engine/config/RuleEngineConfig.java
@@ -1,5 +1,7 @@
 package com.drool.engine.config;
 
+import java.io.IOException;
+
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
@@ -13,10 +15,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
-import java.io.IOException;
 
 @Configuration
 public class RuleEngineConfig {
@@ -54,6 +56,7 @@ public class RuleEngineConfig {
     }
 
     @Bean
+    @Scope("prototype")
     public KieSession kieSession() throws IOException {
         return kieContainer().newKieSession();
     }

--- a/ware-drool-rule/src/main/java/com/drool/engine/controller/RuleController.java
+++ b/ware-drool-rule/src/main/java/com/drool/engine/controller/RuleController.java
@@ -1,19 +1,20 @@
 package com.drool.engine.controller;
 
-import com.drool.engine.entity.QueryParam;
-import com.drool.engine.entity.RuleResult;
-import com.drool.engine.service.RuleEngineService;
+import javax.annotation.Resource;
+
 import org.kie.api.runtime.KieSession;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import javax.annotation.Resource;
+
+import com.drool.engine.config.SpringContextUtil;
+import com.drool.engine.entity.QueryParam;
+import com.drool.engine.entity.RuleResult;
+import com.drool.engine.service.RuleEngineService;
 
 @RestController
 @RequestMapping("/rule")
 public class RuleController {
 
-    @Resource
-    private KieSession kieSession;
     @Resource
     private RuleEngineService ruleEngineService ;
 
@@ -25,6 +26,7 @@ public class RuleController {
         QueryParam queryParam2 = new QueryParam() ;
         queryParam2.setParamId("2");
         queryParam2.setParamSign("-");
+        KieSession kieSession = (KieSession) SpringContextUtil.getBean("kieSession");
         // 入参
         kieSession.insert(queryParam1) ;
         kieSession.insert(queryParam2) ;
@@ -34,5 +36,6 @@ public class RuleController {
         RuleResult resultParam = new RuleResult() ;
         kieSession.insert(resultParam) ;
         kieSession.fireAllRules() ;
+        kieSession.destroy();
     }
 }


### PR DESCRIPTION
现有逻辑中全局使用单例KieSession，生成对象为StatefulKnowledgeSessionImpl，并发场景下调用请求/rule/param，内部无法保证线程安全，导致高cpu&内存占用。

本次修改将kieSession调整为为局部变量。

建议全局单例使用StatelessKieSession对象，每次execute时，由内部负责ksession的创建和销毁。